### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/protect-branch.yml
+++ b/.github/workflows/protect-branch.yml
@@ -5,6 +5,9 @@ on:
       - main
       - develop
 
+permissions:
+  contents: read
+
 jobs:
     build-and-test:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/jfrz38/nestjs-openapi-generator-wrapper/security/code-scanning/13](https://github.com/jfrz38/nestjs-openapi-generator-wrapper/security/code-scanning/13)

Add an explicit `permissions` block to `.github/workflows/protect-branch.yml` at the workflow root (top-level), so it applies to all jobs unless overridden. For the shown workflow, the best minimal setting is:

- `contents: read`

This preserves current functionality (checkout/tests) while enforcing least privilege and resolving the CodeQL finding. No imports, methods, or extra definitions are needed—just YAML configuration change near the top of the workflow, between `on:` and `jobs:` (or immediately after `name:`/`on:` as valid YAML structure).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
