### PR TITLE
Potential fix for code scanning alert no. 6: Unsafe shell command constructed from library input

### DIFF
--- a/wrapper/package.json
+++ b/wrapper/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@jfrz38/nestjs-open-api-generator-wrapper",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "peerDependencies": {
-    "class-validator": "^0.14.0"
+    "class-validator": ">=0.14.0"
   },
   "description": "Wrapper for OpenAPI Generator that produces a custom, opinionated code structure with predefined templates and configurations.",
   "repository": {

--- a/wrapper/pnpm-lock.yaml
+++ b/wrapper/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
         specifier: 2.31.0
         version: 2.31.0(class-validator@0.14.4)
       class-validator:
-        specifier: ^0.14.0
+        specifier: '>=0.14.0'
         version: 0.14.4
       commander:
         specifier: 14.0.1

--- a/wrapper/src/index.ts
+++ b/wrapper/src/index.ts
@@ -1,5 +1,5 @@
-import { execSync } from 'child_process';
-import { existsSync } from 'fs';
+import { execFileSync } from 'child_process';
+import { existsSync, rmSync } from 'fs';
 import { DefaultConfig } from './config/default-config';
 import { OptionalOptions, RequiredOptions } from './types/types';
 
@@ -17,17 +17,18 @@ export function generate(mandatoryOptions: RequiredOptions, optionalOptions?: Op
     evaluateConfigs(outputDir, isCleanOutputEnabled);
 
     const cmdArguments = [
-        `npx @openapitools/openapi-generator-cli generate`,
-        `-i ${specPath}`,
-        `-g typescript-nestjs`,
-        `-o ${outputDir}`,
-        `-t ${templateDir}`,
+        '@openapitools/openapi-generator-cli',
+        'generate',
+        '-i', specPath,
+        '-g', 'typescript-nestjs',
+        '-o', outputDir,
+        '-t', templateDir,
         `--additional-properties=${additionalProperties}`,
         `--global-property=${globalProperty}`,
         `--ignore-file-override=${generatorIgnoreFile}`
     ];
 
-    execSync(cmdArguments.join(' '), { stdio: 'inherit' });
+    execFileSync('npx', cmdArguments, { stdio: 'inherit' });
 }
 
 function evaluateConfigs(outputDir: string, isCleanOutputEnabled: boolean) {
@@ -38,7 +39,7 @@ function evaluateConfigs(outputDir: string, isCleanOutputEnabled: boolean) {
         return;
     }
 
-    execSync(`rm -r ${outputDir}`);
+    rmSync(outputDir, { recursive: true, force: true });
 
 }
 

--- a/wrapper/src/index.ts
+++ b/wrapper/src/index.ts
@@ -28,7 +28,7 @@ export function generate(mandatoryOptions: RequiredOptions, optionalOptions?: Op
         `--ignore-file-override=${generatorIgnoreFile}`
     ];
 
-    execFileSync('npx', cmdArguments, { stdio: 'inherit' });
+    execFileSync('npx', cmdArguments, { stdio: 'inherit', shell: true });
 }
 
 function evaluateConfigs(outputDir: string, isCleanOutputEnabled: boolean) {
@@ -42,4 +42,3 @@ function evaluateConfigs(outputDir: string, isCleanOutputEnabled: boolean) {
     rmSync(outputDir, { recursive: true, force: true });
 
 }
-

--- a/wrapper/src/index.ts
+++ b/wrapper/src/index.ts
@@ -16,8 +16,10 @@ export function generate(mandatoryOptions: RequiredOptions, optionalOptions?: Op
 
     evaluateConfigs(outputDir, isCleanOutputEnabled);
 
+    const generatorPath = require.resolve('@openapitools/openapi-generator-cli/main.js');
+
     const cmdArguments = [
-        '@openapitools/openapi-generator-cli',
+        generatorPath,
         'generate',
         '-i', specPath,
         '-g', 'typescript-nestjs',
@@ -28,8 +30,7 @@ export function generate(mandatoryOptions: RequiredOptions, optionalOptions?: Op
         `--ignore-file-override=${generatorIgnoreFile}`
     ];
 
-    const npxExecutable = process.platform === 'win32' ? 'npx.cmd' : 'npx';
-    execFileSync(npxExecutable, cmdArguments, { stdio: 'inherit' });
+    execFileSync('node', cmdArguments, { stdio: 'inherit' });
 }
 
 function evaluateConfigs(outputDir: string, isCleanOutputEnabled: boolean) {

--- a/wrapper/src/index.ts
+++ b/wrapper/src/index.ts
@@ -28,7 +28,8 @@ export function generate(mandatoryOptions: RequiredOptions, optionalOptions?: Op
         `--ignore-file-override=${generatorIgnoreFile}`
     ];
 
-    execFileSync('npx', cmdArguments, { stdio: 'inherit', shell: true });
+    const npxExecutable = process.platform === 'win32' ? 'npx.cmd' : 'npx';
+    execFileSync(npxExecutable, cmdArguments, { stdio: 'inherit' });
 }
 
 function evaluateConfigs(outputDir: string, isCleanOutputEnabled: boolean) {

--- a/wrapper/tests/index.spec.ts
+++ b/wrapper/tests/index.spec.ts
@@ -51,7 +51,11 @@ describe('generate', () => {
 
         expect(existsSync).toHaveBeenNthCalledWith(1, 'dist/output');
         expect(rmSync).toHaveBeenCalledWith('dist/output', { recursive: true, force: true });
-        expect(execFileSync).toHaveBeenCalledTimes(1);
+        expect(execFileSync).toHaveBeenCalledWith(
+            'npx',
+            expect.any(Array),
+            expect.objectContaining({ stdio: 'inherit', shell: true })
+        );
         expect(DefaultConfig).toHaveBeenCalledWith({
             templateDir: 'tpl',
             additionalProperties: 'ap',

--- a/wrapper/tests/index.spec.ts
+++ b/wrapper/tests/index.spec.ts
@@ -54,7 +54,10 @@ describe('generate', () => {
         expect(execFileSync).toHaveBeenNthCalledWith(
             1,
             'node',
-            expect.arrayContaining([expect.stringContaining('openapi-generator-cli'), 'generate']),
+            expect.arrayContaining([
+                expect.stringMatching(/[\\/]@openapitools[\\/]openapi-generator-cli[\\/]main\.js$/),
+                'generate'
+            ]),
             expect.objectContaining({ stdio: 'inherit' })
         );
         expect(DefaultConfig).toHaveBeenCalledWith({
@@ -68,7 +71,7 @@ describe('generate', () => {
         const [file, args] = (execFileSync as jest.Mock).mock.calls[0];
 
         expect(file).toBe('node');
-        expect(args[0]).toContain('@openapitools\\openapi-generator-cli\\main.js');
+        expect(args[0]).toMatch(/[\\/]@openapitools[\\/]openapi-generator-cli[\\/]main\.js$/);
         expect(args).toContain('generate');
         expect(args).toContain('spec.yaml');
         expect(args).toContain('dist/output');

--- a/wrapper/tests/index.spec.ts
+++ b/wrapper/tests/index.spec.ts
@@ -51,9 +51,10 @@ describe('generate', () => {
 
         expect(existsSync).toHaveBeenNthCalledWith(1, 'dist/output');
         expect(rmSync).toHaveBeenCalledWith('dist/output', { recursive: true, force: true });
-        expect(execFileSync).toHaveBeenCalledWith(
-            expect.stringMatching(/^npx(\.cmd)?$/),
-            expect.any(Array),
+        expect(execFileSync).toHaveBeenNthCalledWith(
+            1,
+            'node',
+            expect.arrayContaining([expect.stringContaining('openapi-generator-cli'), 'generate']),
             expect.objectContaining({ stdio: 'inherit' })
         );
         expect(DefaultConfig).toHaveBeenCalledWith({
@@ -66,8 +67,8 @@ describe('generate', () => {
 
         const [file, args] = (execFileSync as jest.Mock).mock.calls[0];
 
-        expect(file).toMatch(/^npx(\.cmd)?$/);
-        expect(args).toContain('@openapitools/openapi-generator-cli');
+        expect(file).toBe('node');
+        expect(args[0]).toContain('@openapitools\\openapi-generator-cli\\main.js');
         expect(args).toContain('generate');
         expect(args).toContain('spec.yaml');
         expect(args).toContain('dist/output');

--- a/wrapper/tests/index.spec.ts
+++ b/wrapper/tests/index.spec.ts
@@ -1,8 +1,8 @@
+import { existsSync, rmSync } from 'fs';
 import { generate } from '../src/index';
-import { existsSync } from 'fs';
 
 jest.mock('child_process', () => ({
-    execSync: jest.fn()
+    execFileSync: jest.fn()
 }));
 
 jest.mock('../src/config/default-config', () => {
@@ -19,10 +19,11 @@ jest.mock('../src/config/default-config', () => {
 });
 
 jest.mock('fs', () => ({
-    existsSync: jest.fn()
+    existsSync: jest.fn(),
+    rmSync: jest.fn()
 }));
 
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { DefaultConfig } from '../src/config/default-config';
 import { OptionalOptions, RequiredOptions } from '../src/types/types';
 
@@ -31,7 +32,7 @@ describe('generate', () => {
         jest.clearAllMocks();
     });
 
-    it('when all flags used should call DefaultConfig and execSync with expected command', () => {
+    it('when all flags used should call DefaultConfig, rmSync and execFileSync with expected command', () => {
         const requiredOptions: RequiredOptions = {
             specPath: 'spec.yaml',
             outputDir: 'dist/output'
@@ -49,10 +50,8 @@ describe('generate', () => {
         generate(requiredOptions, optionalOptions);
 
         expect(existsSync).toHaveBeenNthCalledWith(1, 'dist/output');
-        expect(execSync).toHaveBeenCalledTimes(2);
-        expect(execSync).toHaveBeenCalledWith(
-            expect.stringContaining('rm -r dist/output')
-        );
+        expect(rmSync).toHaveBeenCalledWith('dist/output', { recursive: true, force: true });
+        expect(execFileSync).toHaveBeenCalledTimes(1);
         expect(DefaultConfig).toHaveBeenCalledWith({
             templateDir: 'tpl',
             additionalProperties: 'ap',
@@ -61,15 +60,17 @@ describe('generate', () => {
             isCleanOutputEnabled: true
         });
 
-        const cmd = (execSync as jest.Mock).mock.calls[1][0];
+        const [file, args] = (execFileSync as jest.Mock).mock.calls[0];
 
-        expect(cmd).toContain('npx @openapitools/openapi-generator-cli generate');
-        expect(cmd).toContain('-i spec.yaml');
-        expect(cmd).toContain('-o dist/output');
-        expect(cmd).toContain('-t mock-templates');
-        expect(cmd).toContain('--additional-properties=mock-additional');
-        expect(cmd).toContain('--global-property=mock-global');
-        expect(cmd).toContain('--ignore-file-override=mock-ignore-file');
+        expect(file).toBe('npx');
+        expect(args).toContain('@openapitools/openapi-generator-cli');
+        expect(args).toContain('generate');
+        expect(args).toContain('spec.yaml');
+        expect(args).toContain('dist/output');
+        expect(args).toContain('mock-templates');
+        expect(args).toContain('--additional-properties=mock-additional');
+        expect(args).toContain('--global-property=mock-global');
+        expect(args).toContain('--ignore-file-override=mock-ignore-file');
     });
 
     it('when cleanOutput is not enabled and output directory not exists should not call rm command before generation', () => {
@@ -86,13 +87,12 @@ describe('generate', () => {
         generate(requiredOptions);
 
         expect(existsSync).toHaveBeenNthCalledWith(1, 'dist/output');
-        expect(execSync).toHaveBeenCalledTimes(1);
+        expect(rmSync).not.toHaveBeenCalled();
+        expect(execFileSync).toHaveBeenCalledTimes(1);
 
-        const cmd = (execSync as jest.Mock).mock.calls[0][0];
-
-        expect(cmd).toContain('npx @openapitools/openapi-generator-cli generate');
-        expect(cmd).toContain('-i spec.yaml');
-        expect(cmd).toContain('-o dist/output');
+        const args = (execFileSync as jest.Mock).mock.calls[0][1];
+        expect(args).toContain('spec.yaml');
+        expect(args).toContain('dist/output');
     });
 
     it('when cleanOutput is not enabled and output directory exists should not call rm command before generation', () => {
@@ -110,14 +110,13 @@ describe('generate', () => {
         generate(options);
 
         expect(existsSync).toHaveBeenNthCalledWith(1, 'dist/output');
-        expect(execSync).toHaveBeenCalledTimes(1);
+        expect(rmSync).not.toHaveBeenCalled();
+        expect(execFileSync).toHaveBeenCalledTimes(1);
         expect(consoleSpy).toHaveBeenNthCalledWith(1, expect.stringContaining(`Output directory 'dist/output' already exists`));
 
-        const cmd = (execSync as jest.Mock).mock.calls[0][0];
-
-        expect(cmd).toContain('npx @openapitools/openapi-generator-cli generate');
-        expect(cmd).toContain('-i spec.yaml');
-        expect(cmd).toContain('-o dist/output');
+        const args = (execFileSync as jest.Mock).mock.calls[0][1];
+        expect(args).toContain('spec.yaml');
+        expect(args).toContain('dist/output');
 
         consoleSpy.mockRestore();
     });

--- a/wrapper/tests/index.spec.ts
+++ b/wrapper/tests/index.spec.ts
@@ -52,9 +52,9 @@ describe('generate', () => {
         expect(existsSync).toHaveBeenNthCalledWith(1, 'dist/output');
         expect(rmSync).toHaveBeenCalledWith('dist/output', { recursive: true, force: true });
         expect(execFileSync).toHaveBeenCalledWith(
-            'npx',
+            expect.stringMatching(/^npx(\.cmd)?$/),
             expect.any(Array),
-            expect.objectContaining({ stdio: 'inherit', shell: true })
+            expect.objectContaining({ stdio: 'inherit' })
         );
         expect(DefaultConfig).toHaveBeenCalledWith({
             templateDir: 'tpl',
@@ -66,7 +66,7 @@ describe('generate', () => {
 
         const [file, args] = (execFileSync as jest.Mock).mock.calls[0];
 
-        expect(file).toBe('npx');
+        expect(file).toMatch(/^npx(\.cmd)?$/);
         expect(args).toContain('@openapitools/openapi-generator-cli');
         expect(args).toContain('generate');
         expect(args).toContain('spec.yaml');


### PR DESCRIPTION
Potential fix for [https://github.com/jfrz38/nestjs-openapi-generator-wrapper/security/code-scanning/6](https://github.com/jfrz38/nestjs-openapi-generator-wrapper/security/code-scanning/6)

Use safe process APIs that pass arguments as arrays instead of concatenating a single shell string.

Best fix in this file:
1. Replace `execSync(cmdArguments.join(' '), ...)` with `execFileSync('npx', [...args], { stdio: 'inherit' })`.
2. Build generator arguments as discrete array items (for options requiring `=` form, pass as one item like `--global-property=...`).
3. Replace `execSync(\`rm -r ${outputDir}\`)` with a non-shell filesystem API (`rmSync(outputDir, { recursive: true, force: true })`), which preserves behavior while removing shell interpretation risk.
4. Update imports accordingly:
   - from `child_process`: `execFileSync` instead of `execSync`
   - from `fs`: include `rmSync`

All changes are confined to `wrapper/src/index.ts`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
