### PR TITLE
Add cooldown for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/wrapper"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
     versioning-strategy: increase
     commit-message:
       prefix: "[Dependency Update]"
@@ -15,6 +17,8 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "[CI Update]"
     groups:


### PR DESCRIPTION
Added cooldown period of 7 days for npm and GitHub Actions updates.