### PR TITLE
fix: generate Request and Response parameters as non-null

### DIFF
--- a/wrapper/src/templates/api.service.mustache
+++ b/wrapper/src/templates/api.service.mustache
@@ -19,7 +19,7 @@ export abstract class {{classname}} {
 
   {{#operations}}
   {{#operation}}
-  protected abstract {{operationId}}({{#allParams}}{{paramName}}: {{{dataType}}}{{^required}} | undefined{{/required}}, {{/allParams}}request?: Request, response?: Response): {{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}} | Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}>;
+  protected abstract {{operationId}}({{#allParams}}{{paramName}}: {{{dataType}}}{{^required}} | undefined{{/required}}, {{/allParams}}request: Request, response: Response): {{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}} | Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}>;
 
   {{/operation}}
   {{/operations}}
@@ -33,7 +33,7 @@ export abstract class {{classname}} {
      {{/allParams}}
      */
     @{{#lambda.pascalcase}}{{{operationId}}}Path{{/lambda.pascalcase}}()
-    private do{{#lambda.pascalcase}}{{{operationId}}}{{/lambda.pascalcase}}({{#allParams}}{{#isPathParam}}@Param("{{baseName}}") {{/isPathParam}}{{#isQueryParam}}@Query("{{baseName}}") {{/isQueryParam}}{{#isHeaderParam}}@Headers("{{baseName}}") {{/isHeaderParam}}{{#isBodyParam}}@Body() {{/isBodyParam}}{{paramName}}: {{{dataType}}}{{^required}} | undefined{{/required}}, {{/allParams}}@Req() request?: Request, @Res({ passthrough: true }) response?: Response): {{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}} | Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}> {
+    private do{{#lambda.pascalcase}}{{{operationId}}}{{/lambda.pascalcase}}({{#allParams}}{{#isPathParam}}@Param("{{baseName}}") {{/isPathParam}}{{#isQueryParam}}@Query("{{baseName}}") {{/isQueryParam}}{{#isHeaderParam}}@Headers("{{baseName}}") {{/isHeaderParam}}{{#isBodyParam}}@Body() {{/isBodyParam}}{{paramName}}: {{{dataType}}}{{^required}} | undefined{{/required}}, {{/allParams}}@Req() request: Request, @Res({ passthrough: true }) response: Response): {{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}} | Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}> {
       {{#allParams}}
       {{#required}}
         {{#isConstEnumParam}}


### PR DESCRIPTION
## Summary
Generate `request` and `response` parameters as non-null in the NestJS API template.

In NestJS, `@Req()` and `@Res()` decorators always provide Request and Response objects — they are never null or undefined at runtime. The generated template was marking these parameters as optional (request?: Request, response?: Response), which forces consumers to use '!' or '?' everywhere.

This change removes the optional markers from both:
- Abstract method signatures (e.g., `getUsers(request: Request, response: Response)`)
- Concrete `do*` method implementations (e.g., `@Req() request: Request, @Res({ passthrough: true }) response: Response`)

## Related
Closes #68