### PR TITLE
chore: migrate workspace to pnpm 11.1.3

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6.0.3
         with:
-          version: 10
+          package_json_file: wrapper/package.json
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6.0.3
         with:
-          version: 10
+          package_json_file: wrapper/package.json
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.github/workflows/protect-branch.yml
+++ b/.github/workflows/protect-branch.yml
@@ -15,7 +15,7 @@ jobs:
           - uses: actions/checkout@v6
           - uses: pnpm/action-setup@v6.0.3
             with:
-              version: 10
+              package_json_file: wrapper/package.json
           - uses: actions/setup-node@v6
             with:
               node-version: '20.x'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6.0.3
         with:
-          version: 10
+          package_json_file: wrapper/package.json
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
+.pnpm-store/
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json

--- a/wrapper/.npmrc
+++ b/wrapper/.npmrc
@@ -1,3 +1,0 @@
-enablePrePostScripts=false
-minimumReleaseAge=4320
-save-exact=true

--- a/wrapper/package.json
+++ b/wrapper/package.json
@@ -31,6 +31,7 @@
   ],
   "author": "José F. Ruiz Zamora <jrz899@inlumine.ual.es>",
   "license": "MIT",
+  "packageManager": "pnpm@11.1.3",
   "dependencies": {
     "@openapitools/openapi-generator-cli": "2.31.0",
     "commander": "14.0.1"

--- a/wrapper/pnpm-workspace.yaml
+++ b/wrapper/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+enablePrePostScripts: false
+minimumReleaseAge: 4320
+saveExact: true

--- a/wrapper/pnpm-workspace.yaml
+++ b/wrapper/pnpm-workspace.yaml
@@ -1,3 +1,7 @@
 enablePrePostScripts: false
 minimumReleaseAge: 4320
 saveExact: true
+allowBuilds:
+  '@nestjs/core': true
+  '@openapitools/openapi-generator-cli': true
+  unrs-resolver: true


### PR DESCRIPTION
Migrate the workspace to pnpm 11.1.3, move pnpm project settings into pnpm-workspace.yaml, and make GitHub Actions use the pinned packageManager version.