### PR TITLE
[iss-68] Generate `request` and `response` parameters as no-null

### DIFF
--- a/.github/workflows/protect-branch.yml
+++ b/.github/workflows/protect-branch.yml
@@ -18,7 +18,7 @@ jobs:
               package_json_file: wrapper/package.json
           - uses: actions/setup-node@v6
             with:
-              node-version: '20.x'
+              node-version: '24'
               cache: 'pnpm'
               cache-dependency-path: wrapper/pnpm-lock.yaml
               

--- a/wrapper/src/templates/api.service.mustache
+++ b/wrapper/src/templates/api.service.mustache
@@ -19,7 +19,7 @@ export abstract class {{classname}} {
 
   {{#operations}}
   {{#operation}}
-  protected abstract {{operationId}}({{#allParams}}{{paramName}}: {{{dataType}}}{{^required}} | undefined{{/required}}, {{/allParams}}request?: Request, response?: Response): {{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}} | Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}>;
+  protected abstract {{operationId}}({{#allParams}}{{paramName}}: {{{dataType}}}{{^required}} | undefined{{/required}}, {{/allParams}}request: Request, response: Response): {{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}} | Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}>;
 
   {{/operation}}
   {{/operations}}
@@ -33,7 +33,7 @@ export abstract class {{classname}} {
      {{/allParams}}
      */
     @{{#lambda.pascalcase}}{{{operationId}}}Path{{/lambda.pascalcase}}()
-    private do{{#lambda.pascalcase}}{{{operationId}}}{{/lambda.pascalcase}}({{#allParams}}{{#isPathParam}}@Param("{{baseName}}") {{/isPathParam}}{{#isQueryParam}}@Query("{{baseName}}") {{/isQueryParam}}{{#isHeaderParam}}@Headers("{{baseName}}") {{/isHeaderParam}}{{#isBodyParam}}@Body() {{/isBodyParam}}{{paramName}}: {{{dataType}}}{{^required}} | undefined{{/required}}, {{/allParams}}@Req() request?: Request, @Res({ passthrough: true }) response?: Response): {{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}} | Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}> {
+    private do{{#lambda.pascalcase}}{{{operationId}}}{{/lambda.pascalcase}}({{#allParams}}{{#isPathParam}}@Param("{{baseName}}") {{/isPathParam}}{{#isQueryParam}}@Query("{{baseName}}") {{/isQueryParam}}{{#isHeaderParam}}@Headers("{{baseName}}") {{/isHeaderParam}}{{#isBodyParam}}@Body() {{/isBodyParam}}{{paramName}}: {{{dataType}}}{{^required}} | undefined{{/required}}, {{/allParams}}@Req() request: Request, @Res({ passthrough: true }) response: Response): {{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}} | Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}> {
       {{#allParams}}
       {{#required}}
         {{#isConstEnumParam}}

--- a/wrapper/tests/integration/api-template.integration.spec.ts
+++ b/wrapper/tests/integration/api-template.integration.spec.ts
@@ -39,8 +39,8 @@ describeIntegration('template integration', () => {
         const generatedApi = readFileSync(join(outputDir, 'api', 'reports.api.ts'), 'utf8');
 
         expect(generatedApi).toContain(`import type { Request, Response } from 'express';`);
-        expect(generatedApi).toContain(`protected abstract listReports(visibility: 'private' | 'shared' | undefined, request?: Request, response?: Response): void | Promise<void>;`);
-        expect(generatedApi).toContain(`private doListReports(@Query("visibility") visibility: 'private' | 'shared' | undefined, @Req() request?: Request, @Res({ passthrough: true }) response?: Response): void | Promise<void> {`);
+        expect(generatedApi).toContain(`protected abstract listReports(visibility: 'private' | 'shared' | undefined, request: Request, response: Response): void | Promise<void>;`);
+        expect(generatedApi).toContain(`private doListReports(@Query("visibility") visibility: 'private' | 'shared' | undefined, @Req() request: Request, @Res({ passthrough: true }) response: Response): void | Promise<void> {`);
         expect(generatedApi).not.toContain(`VisibilityEnum`);
     });
 


### PR DESCRIPTION
Closes #68 